### PR TITLE
updating package.json for latest passport-oauth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-bufferapp",
-  "version": "0.1",
+  "version": "0.1.0",
   "description": "Bufferapp authentication strategy for Passport.",
   "author": {
     "name": "Sébastien De Bollivier",
@@ -16,7 +16,7 @@
   "main": "./lib/",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "1.x.x"
   },
   "engines": {
     "node": ">= 0.4.0"
@@ -30,7 +30,7 @@
   "keywords": [
     "passport",
     "bufferapp",
-    "oauth2"
+    "oauth2",
     "auth",
     "authn",
     "authentication",


### PR DESCRIPTION
Fixing error of “TypeError: Cannot set property 'user' of undefined” when authenticating successfully. This is caused by the latest passport release (0.3.0) being dependent on ("passport-oauth": "1.x.x"). See [this](https://github.com/jaredhanson/passport/issues/400) for more. 
